### PR TITLE
Remove dependency on logging package

### DIFF
--- a/src/SwedbankPay.Sdk/SwedbankPay.Sdk.csproj
+++ b/src/SwedbankPay.Sdk/SwedbankPay.Sdk.csproj
@@ -20,7 +20,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Dependency is not needed, and is a blocker for people implementing this in .Net Core 2.2