### PR TITLE
Update what we pack

### DIFF
--- a/src/SwedbankPay.Sdk.nuspec
+++ b/src/SwedbankPay.Sdk.nuspec
@@ -21,7 +21,6 @@
     </metadata>
     <files>
         <file src="../icon.png" target="" />
-        <file src="../SwedbankPay.Sdk/bin/Release/netstandard2.1/SwedbankPay*.*" target="lib/netstandard2.1" />
         <file src="../SwedbankPay.Sdk.Infrastructure/bin/Release/netstandard2.1/SwedbankPay*.*" target="lib/netstandard2.1" />
     </files>
 </package>


### PR DESCRIPTION
This avoids us packing `SwedbankPay.Sdk.dll` twice