### PR TITLE
Update project reference properties in SwedbankPay.Sdk.Extensions.csproj

### DIFF
--- a/src/SwedbankPay.Sdk.Extensions/SwedbankPay.Sdk.Extensions.csproj
+++ b/src/SwedbankPay.Sdk.Extensions/SwedbankPay.Sdk.Extensions.csproj
@@ -32,7 +32,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\SwedbankPay.Sdk.Infrastructure\SwedbankPay.Sdk.Infrastructure.csproj" />
-      <ProjectReference Include="..\SwedbankPay.Sdk\SwedbankPay.Sdk.csproj" />
+      <ProjectReference Include="..\SwedbankPay.Sdk\SwedbankPay.Sdk.csproj" PrivateAssets="All" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This commit modifies the SwedbankPay.Sdk.Extensions.csproj to change the properties of the project reference to SwedbankPay.Sdk. Now, all the project's assets are marked as private to ensure they are not exposed or shared with other projects unintentionally.