### PR TITLE
Add properties to PaymentOrder classes

### DIFF
--- a/src/SwedbankPay.Sdk.Infrastructure/PaymentOrder/PaymentOrderDto.cs
+++ b/src/SwedbankPay.Sdk.Infrastructure/PaymentOrder/PaymentOrderDto.cs
@@ -22,6 +22,8 @@ internal record PaymentOrderDto
         PaymentToken = paymentOrderRequest.PaymentToken;
         GeneratePaymentToken = paymentOrderRequest.GeneratePaymentToken;
         Language = paymentOrderRequest.Language.ToString();
+        ExpandFirstInstrument = paymentOrderRequest.ExpandFirstInstrument;
+        RestrictedToInstruments = paymentOrderRequest.RestrictedToInstruments?.Select(x => x.Value).ToArray();
         GenerateRecurrenceToken = paymentOrderRequest.GenerateRecurrenceToken;
         GenerateUnscheduledToken = paymentOrderRequest.GenerateUnscheduledToken;
         DisableStoredPaymentDetails = paymentOrderRequest.DisableStoredPaymentDetails;
@@ -59,6 +61,8 @@ internal record PaymentOrderDto
     public bool? GeneratePaymentToken { get;  }
     public string? PaymentToken { get; }
     public string Language { get; }
+    public string[]? RestrictedToInstruments { get; }
+    public bool? ExpandFirstInstrument { get; }
     public bool? GenerateRecurrenceToken { get; }  
     public bool? GenerateUnscheduledToken { get; }
     public bool? DisableStoredPaymentDetails { get;  }

--- a/src/SwedbankPay.Sdk/PaymentOrder/PaymentOrderRequest.cs
+++ b/src/SwedbankPay.Sdk/PaymentOrder/PaymentOrderRequest.cs
@@ -27,6 +27,8 @@ public record PaymentOrderRequest(
     public bool? GeneratePaymentToken { get; set; }
     public string? PaymentToken { get; set; }
     public Language Language { get; } = Language;
+    public bool? ExpandFirstInstrument { get; set; }
+    public List<PaymentInstrument>? RestrictedToInstruments { get; set; }
     public bool? GenerateRecurrenceToken { get; set; }
     public bool? GenerateUnscheduledToken { get; set; }
     public bool? DisableStoredPaymentDetails { get; set; }


### PR DESCRIPTION
Two new properties have been added to the PaymentOrderRequest and PaymentOrderDto classes. The "ExpandFirstInstrument" boolean and "RestrictedToInstruments" list will provide additional functionality concerning payment instruments in the SwedbankPay SDK.