### PR TITLE
Refactor AddressDto to handle non-nullable address

### DIFF
--- a/src/SwedbankPay.Sdk.Infrastructure/AddressDto.cs
+++ b/src/SwedbankPay.Sdk.Infrastructure/AddressDto.cs
@@ -2,18 +2,18 @@ namespace SwedbankPay.Sdk.Infrastructure;
 
 internal record AddressDto
 {
-    public AddressDto(Sdk.PaymentOrder.Address? address)
+    public AddressDto(Sdk.PaymentOrder.Address address)
     {
-        Name = address?.Name;
-        FirstName = address?.FirstName;
-        LastName = address?.LastName;
-        Email = address?.Email?.ToString();
-        Msisdn = address?.Msisdn?.ToString();
-        StreetAddress = address?.StreetAddress;
-        CoAddress = address?.CoAddress;
-        City = address?.City;
-        ZipCode = address?.ZipCode;
-        CountryCode = address?.CountryCode?.ToString();
+        Name = address.Name;
+        FirstName = address.FirstName;
+        LastName = address.LastName;
+        Email = address.Email?.ToString();
+        Msisdn = address.Msisdn?.ToString();
+        StreetAddress = address.StreetAddress;
+        CoAddress = address.CoAddress;
+        City = address.City;
+        ZipCode = address.ZipCode;
+        CountryCode = address.CountryCode?.ToString();
     }
 
     public string? Name { get; }

--- a/src/SwedbankPay.Sdk.Infrastructure/PaymentOrder/Payer/PayerRequestDto.cs
+++ b/src/SwedbankPay.Sdk.Infrastructure/PaymentOrder/Payer/PayerRequestDto.cs
@@ -11,8 +11,8 @@ internal record PayerRequestDto
         Msisdn = payer.Msisdn?.ToString();
         WorkPhoneNumber = payer.WorkPhoneNumber?.ToString();
         HomePhoneNumber = payer.HomePhoneNumber?.ToString();
-        BillingAddress = new AddressDto(payer.BillingAddress);
-        ShippingAddress = new AddressDto(payer.ShippingAddress);
+        BillingAddress = payer.BillingAddress != null ? new AddressDto(payer.BillingAddress) :  null;
+        ShippingAddress = payer.ShippingAddress != null ? new AddressDto(payer.ShippingAddress) : null;
         AccountInfo = new AccountInfoDto(payer.AccountInfo);
     }
 

--- a/src/SwedbankPay.Sdk.Infrastructure/PaymentOrder/RiskIndicator/RiskIndicatorRequestDto.cs
+++ b/src/SwedbankPay.Sdk.Infrastructure/PaymentOrder/RiskIndicator/RiskIndicatorRequestDto.cs
@@ -13,7 +13,7 @@ internal record RiskIndicatorRequestDto
         ShipIndicator = riskIndicator.ShipIndicator?.Value;
         GiftCardPurchase = riskIndicator.GiftCardPurchase;
         ReOrderPurchaseIndicator = riskIndicator.ReOrderPurchaseIndicator?.Value;
-        PickUpAddress = new AddressDto(riskIndicator.PickUpAddress);
+        PickUpAddress = riskIndicator.PickUpAddress != null ? new AddressDto(riskIndicator.PickUpAddress) : null;
     }
     
     public string? DeliveryEmailAddress { get; }


### PR DESCRIPTION
This commit modifies the handling of address in AddressDto, specifically, the constructor now no longer accepts a nullable Address, enforcing that an Address must be provided. For classes employing AddressDto - "PayerRequestDto" and "RiskIndicatorRequestDto" - modifications were made to handle potential null Addresses, checking for null before initializing a new AddressDto.