### PR TITLE
Map TermsOfServiceUrl

### DIFF
--- a/src/SwedbankPay.Sdk.Infrastructure/PaymentOrder/Urls/UrlsRequestDto.cs
+++ b/src/SwedbankPay.Sdk.Infrastructure/PaymentOrder/Urls/UrlsRequestDto.cs
@@ -12,6 +12,7 @@ internal record UrlsRequestDto
         CancelUrl = urls.CancelUrl?.ToString();
         CallbackUrl = urls.CallbackUrl?.ToString();
         LogoUrl = urls.LogoUrl?.ToString();
+        TermsOfServiceUrl = urls.TermsOfServiceUrl?.ToString();
     }
     
     public string? Id { get; set; }
@@ -21,4 +22,5 @@ internal record UrlsRequestDto
     public string? CancelUrl { get; set; }
     public string? CallbackUrl { get; set; }
     public string? LogoUrl { get; set; }
+    public string? TermsOfServiceUrl { get; set; }
 }


### PR DESCRIPTION
Fix issue where TermsOfServiceUrl is not mapped
The URL not being mapped means it is not sent in the request, resulting in not being able to show the term and conditions content in the seemless view.