### PR TITLE
Add Terms of Service handling to checkout process in sample site

### DIFF
--- a/src/Samples/Sample.AspNetCore/Controllers/TermsController.cs
+++ b/src/Samples/Sample.AspNetCore/Controllers/TermsController.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Sample.AspNetCore.Controllers;
+
+public class TermsController : Controller
+{
+    public IActionResult Index()
+    {
+        return View();
+    }
+}

--- a/src/Samples/Sample.AspNetCore/Views/Checkout/_SwedbankPayCheckout.cshtml
+++ b/src/Samples/Sample.AspNetCore/Views/Checkout/_SwedbankPayCheckout.cshtml
@@ -68,6 +68,7 @@
 	function onTermsOfServiceRequested(obj){
 		console.log("Terms of service requested event:");
 		console.log(obj)
+		window.open(obj.termsOfServiceUrl, '_blank');
 	}
 	
 	function onEventNotification(obj){

--- a/src/Samples/Sample.AspNetCore/Views/Terms/Index.cshtml
+++ b/src/Samples/Sample.AspNetCore/Views/Terms/Index.cshtml
@@ -1,0 +1,13 @@
+<h1>Terms of Payment</h1>
+
+<p>By making a payment, you agree to the following terms and conditions:</p>
+
+<ul>
+    <li>All payments are non-refundable unless otherwise stated.</li>
+    <li>Payments must be made in full before the delivery of any goods or services.</li>
+    <li>We accept the following payment methods: credit card, debit card, and PayPal.</li>
+    <li>Any disputes regarding payments must be reported within 30 days of the transaction date.</li>
+    <li>We reserve the right to change our payment terms at any time without prior notice.</li>
+</ul>
+
+<p>If you have any questions or concerns about our payment terms, please contact our support team.</p>


### PR DESCRIPTION
Introduced IHttpContextAccessor to CheckOutController for dynamically generating Terms of Service URL. Created a new TermsController with an associated view to display payment terms. Enhanced SwedbankPayCheckout view to open terms in a new tab.