### PR TITLE
Resolves #654 Add ProductCategory property to PayeeInfo

### DIFF
--- a/.github/workflows/test_deploy_samplesite.yml
+++ b/.github/workflows/test_deploy_samplesite.yml
@@ -28,7 +28,7 @@ jobs:
    
     steps:
       - name: "Get information about the origin 'CI' run"
-        uses: potiuk/get-workflow-origin@v1_1
+        uses: potiuk/get-workflow-origin@v1_6
         id: source-run-info
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/Samples/Sample.AspNetCore/Controllers/CheckOutController.cs
+++ b/src/Samples/Sample.AspNetCore/Controllers/CheckOutController.cs
@@ -171,6 +171,7 @@ public class CheckOutController : Controller
                 {
                     PayeeId = _payeeInfoOptions.PayeeId,
                     OrderReference = $"PO-{DateTime.UtcNow.Ticks}",
+                    ProductCategory = "A100",
                     Subsite = "TestSubsiteId",
                     SiteId = "TestSiteId"
                 })

--- a/src/SwedbankPay.Sdk.Infrastructure/PayeeInfoDto.cs
+++ b/src/SwedbankPay.Sdk.Infrastructure/PayeeInfoDto.cs
@@ -7,6 +7,7 @@ internal record PayeeInfoDto
         PayeeId = payeeInfo.PayeeId;
         PayeeReference = payeeInfo.PayeeReference;
         PayeeName = payeeInfo.PayeeName;
+        ProductCategory = payeeInfo.ProductCategory;
         OrderReference = payeeInfo.OrderReference;
         Subsite = payeeInfo.Subsite;
         SiteId = payeeInfo.SiteId;
@@ -15,6 +16,7 @@ internal record PayeeInfoDto
     public string? PayeeId { get; init; }
     public string PayeeReference { get; init; }
     public string? PayeeName { get; init; }
+    public string? ProductCategory { get; init; }
     public string? OrderReference { get; init; }
     public string? Subsite { get; init; }
     public string? SiteId { get; init; }

--- a/src/SwedbankPay.Sdk/PayeeInfo.cs
+++ b/src/SwedbankPay.Sdk/PayeeInfo.cs
@@ -11,6 +11,13 @@ public record PayeeInfo(string PayeeReference)
     public string? PayeeName { get; init; }
 
     /// <summary>
+    ///     A product category or number sent in from the payee/merchant. This is not validated by Swedbank Pay,
+    ///     but will be passed through the payment process and may be used in the settlement process.
+    ///     You therefore need to ensure that the value given here is valid in the settlement.
+    /// </summary>
+    public string? ProductCategory { get; init; }
+    
+    /// <summary>
     ///     The order reference should reflect the order reference found in the merchant's systems.
     /// </summary>
     public string? OrderReference { get; init; }


### PR DESCRIPTION
Introduced the ProductCategory property to the PayeeInfo model, DTOs, and its usage in the CheckOutController. This field allows merchants to specify a product category or number for settlement purposes.