### PR TITLE
Update target frameworks: drop EOL net6/net7, add net9/net10

### DIFF
--- a/.github/workflows/deploy_pro_package_samplesite.yml
+++ b/.github/workflows/deploy_pro_package_samplesite.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Download artifact
         id: download-artifact
-        uses: dawidd6/action-download-artifact@v10
+        uses: dawidd6/action-download-artifact@4c1e823582f43b179e2cbb49c3eade4e41f992e2 # v10
         with:
           workflow_conclusion: success
           run_id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -24,9 +24,9 @@ on:
 
 env:
   dotnetVersion: |
-    6.x
-    7.x
     8.x
+    9.x
+    10.x
   AZURE_WEBAPP_PACKAGE_PATH: '.'
 
 jobs:

--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -35,10 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: ${{ env.dotnetVersion }}
  
@@ -49,7 +49,7 @@ jobs:
         run: dotnet publish --configuration ${{ inputs.Configuration }} -p:Version=${{ inputs.nuGetVersionV2 }} --no-restore ${{ inputs.SampleSiteCsprojPath }} --output '${{ env.AZURE_WEBAPP_PACKAGE_PATH }}/samplesite'
 
       - name: Archive Sample.AspNetCore
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: Sample.AspNetCore
           path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}/samplesite
@@ -61,7 +61,7 @@ jobs:
         run: dotnet pack ./src/SwedbankPay.Sdk.Extensions/SwedbankPay.Sdk.Extensions.csproj -p:PackageVersion=${{ inputs.NUGETVERSIONV2 }} -p:Version=${{ inputs.NUGETVERSIONV2 }} --no-restore --configuration=${{ inputs.Configuration }} --output=artifacts
 
       - name: Archive nuget packages artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           # Artifact name
           name: packages

--- a/.github/workflows/template_publish_webapp.yml
+++ b/.github/workflows/template_publish_webapp.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Download artifact
         id: download-artifact
-        uses: dawidd6/action-download-artifact@v10
+        uses: dawidd6/action-download-artifact@4c1e823582f43b179e2cbb49c3eade4e41f992e2 # v10
         with:
           workflow_conclusion: success
           run_id: ${{ inputs.WorkflowRunId }}
@@ -27,7 +27,7 @@ jobs:
           path: Sample.AspNetCore
     
       - name: Variable Substitution
-        uses: microsoft/variable-substitution@v1
+        uses: microsoft/variable-substitution@6287962da9e5b6e68778dc51e840caa03ca84495 # v1
         with:
          # comma separated list of XML/JSON/YAML files in which tokens are to be substituted. Files names must be specified relative to the folder-path.
            files: 'Sample.AspNetCore/appsettings.json'
@@ -45,7 +45,7 @@ jobs:
           Urls.HostUrls.0: https://swedbankpay-sdk-001-${{ inputs.Environment }}.azurewebsites.net/
           
       - name: 'Run Azure webapp deploy using publish profile credentials'
-        uses: azure/webapps-deploy@v3
+        uses: azure/webapps-deploy@02a81bead70021f5284939794bcec79c271ab383 # v3
         with: 
           app-name: ${{ secrets.AZURE_WEBAPP_NAME }} # Replace with your app name
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }} # Define secret variable in repository settings as per action documentation

--- a/.github/workflows/template_version.yml
+++ b/.github/workflows/template_version.yml
@@ -14,15 +14,15 @@ jobs:
       NUGETVERSIONV2: ${{ steps.gitversion.outputs.NUGETVERSIONV2 }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0   
 
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v3
+        uses: gittools/actions/gitversion/setup@51d325634925d7d9ce0a7efc2c586c0bc2b9eee6 # v3.2.1
         with:
           versionSpec: '5.x'
  
       - name: Use GitVersion
         id: gitversion # step id used as reference for output values
-        uses: gittools/actions/gitversion/execute@v3
+        uses: gittools/actions/gitversion/execute@51d325634925d7d9ce0a7efc2c586c0bc2b9eee6 # v3.2.1

--- a/.github/workflows/test_deploy_samplesite.yml
+++ b/.github/workflows/test_deploy_samplesite.yml
@@ -7,8 +7,8 @@ on:
 
 env:
   dotnetVersion: |
-    6.x
     8.x
+    10.x
 
 jobs:
   test-unit-ui:

--- a/.github/workflows/test_deploy_samplesite.yml
+++ b/.github/workflows/test_deploy_samplesite.yml
@@ -28,16 +28,16 @@ jobs:
    
     steps:
       - name: "Get information about the origin 'CI' run"
-        uses: potiuk/get-workflow-origin@v1_5
+        uses: potiuk/get-workflow-origin@e2dae063368361e4cd1f510e8785cd73bca9352e # v1_5
         id: source-run-info
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           sourceRunId: ${{ github.event.workflow_run.id }}
      
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
                     
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: ${{ env.dotnetVersion }}
 
@@ -54,7 +54,7 @@ jobs:
           dotnet test ./src/SwedbankPay.Sdk.Tests/SwedbankPay.Sdk.Tests.csproj
 
       - name: Cypress run
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@f790eee7a50d9505912f50c2095510be7de06aa7 # v6.10.9
         with:
           working-directory: ./src/Samples/Sample.AspNetCore.UiTests
           start: dotnet run --project ../Sample.AspNetCore/Sample.AspNetCore.csproj --urls https://localhost:5001 --SwedbankPay:PayeeId ${{ secrets.MERCHANT_PAYEEID }} --SwedbankPay:Token ${{ secrets.MERCHANT_TOKEN }}
@@ -65,7 +65,7 @@ jobs:
           
           
       - name: Upload Cypress artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ always() }}
         with:
           name: cypress-screenshots
@@ -74,7 +74,7 @@ jobs:
       
       - name: Commit Action Status
         if: ${{ always() }}
-        uses: LouisBrunner/checks-action@v2.0.0
+        uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
         with:
           sha: ${{ steps.source-run-info.outputs.sourceHeadSha }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -91,7 +91,7 @@ jobs:
     steps:
       - name: Download artifact
         id: download-artifact
-        uses: dawidd6/action-download-artifact@v10
+        uses: dawidd6/action-download-artifact@4c1e823582f43b179e2cbb49c3eade4e41f992e2 # v10
         with:
           workflow_conclusion: success
           run_id: ${{ github.event.workflow_run.id }}

--- a/src/Samples/Sample.AspNetCore/Sample.AspNetCore.csproj
+++ b/src/Samples/Sample.AspNetCore/Sample.AspNetCore.csproj
@@ -1,29 +1,29 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <UserSecretsId>04B663D5-41D4-4161-92E7-970FC5A865A9</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.3">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />   
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\SwedbankPay.Sdk.Extensions\SwedbankPay.Sdk.Extensions.csproj" />
     <ProjectReference Include="..\..\SwedbankPay.Sdk\SwedbankPay.Sdk.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <None Update="appsettings.json">
       <CopyToPublishDirectory>Always</CopyToPublishDirectory>

--- a/src/SwedbankPay.Sdk.Infrastructure/SwedbankPay.Sdk.Infrastructure.csproj
+++ b/src/SwedbankPay.Sdk.Infrastructure/SwedbankPay.Sdk.Infrastructure.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>Latest</LangVersion>
@@ -34,17 +34,8 @@
         <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="System.Text.Json" Version="8.0.0"/>
-    </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-        <PackageReference Include="System.Text.Json" Version="7.0.0"/>
-    </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-        <PackageReference Include="System.Text.Json" Version="6.0.0"/>
-    </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-        <PackageReference Include="System.Text.Json" Version="5.0.0"/>
+        <PackageReference Include="System.Text.Json" Version="8.0.5"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/SwedbankPay.Sdk/SwedbankPay.Sdk.csproj
+++ b/src/SwedbankPay.Sdk/SwedbankPay.Sdk.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <IsPackable>false</IsPackable>
-        <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>


### PR DESCRIPTION
.NET 6 (EOL Nov 2024) and .NET 7 (EOL May 2024) no longer receive security patches. Both supported LTS targets (.NET 8, .NET 10) and the currently supported STS (.NET 9) are now included instead.

- SwedbankPay.Sdk and SwedbankPay.Sdk.Infrastructure now target netstandard2.0;net8.0;net9.0;net10.0
- Per-TFM System.Text.Json PackageReferences for net6/net7/net8 removed; the framework-provided version is used on .NET 8+. netstandard2.0 keeps an explicit reference, bumped to 8.0.5 (patches the previously flagged NU1903 vulnerabilities).
- Sample.AspNetCore migrated to net10.0 with Microsoft.* packages bumped to 10.0.0.
- CI workflows updated to install .NET 8/9/10 (template_build) and .NET 8/10 (test_deploy_samplesite).

Test projects remain on net8.0 — they exercise the SDK on a single supported runtime, no need to multi-target.

Breaking change for consumers running on .NET 6 or .NET 7. They must upgrade to .NET 8 or later (or use the netstandard2.0 target if running on .NET Framework).