### PR TITLE
Remove unused Microsoft.Extensions.Http.Polly dependency

### DIFF
--- a/src/Samples/Sample.AspNetCore/Sample.AspNetCore.csproj
+++ b/src/Samples/Sample.AspNetCore/Sample.AspNetCore.csproj
@@ -14,7 +14,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Sample.AspNetCore references Microsoft.Extensions.Http.Polly but nothing in the C# code uses it — no AddHttpClient calls, no AddPolicyHandler chains, no Polly using statements. The package has been a dead dependency, pulling in legacy Polly 7.x and an extra layer of transitive packages for no reason.

If the sample later needs resilient HTTP retries, the modern replacement is Microsoft.Extensions.Http.Resilience — but that is a separate decision when there is actual code to support.