### PR TITLE
Make HttpClientExtensions internal

### DIFF
--- a/src/SwedbankPay.Sdk.Infrastructure/Extensions/HttpClientExtensions.cs
+++ b/src/SwedbankPay.Sdk.Infrastructure/Extensions/HttpClientExtensions.cs
@@ -6,29 +6,29 @@ using SwedbankPay.Sdk.Exceptions;
 
 namespace SwedbankPay.Sdk.Infrastructure.Extensions;
 
-public static class HttpClientExtensions
+internal static class HttpClientExtensions
 {
     private static readonly JsonSerializerOptions? SerializationSettings = JsonSerialization.JsonSerialization.Settings;
 
-    public static async Task<T?> GetAsJsonAsync<T>(this HttpClient httpClient, Uri uri)
+    internal static async Task<T?> GetAsJsonAsync<T>(this HttpClient httpClient, Uri uri)
     {
         using var apiResponse = await httpClient.GetAsync(uri);
         return await ProcessResponse<T>(apiResponse, httpClient, uri);
     }
 
-    public static Task<T?> PostAsJsonAsync<T>(this HttpClient httpClient, Uri uri, object? payload)
+    internal static Task<T?> PostAsJsonAsync<T>(this HttpClient httpClient, Uri uri, object? payload)
         where T : class
     {
         return httpClient.SendAndProcessAsync<T>(HttpMethod.Post, uri, payload);
     }
 
-    public static Task<T?> SendAsJsonAsync<T>(this HttpClient httpClient, HttpMethod httpMethod, Uri uri)
+    internal static Task<T?> SendAsJsonAsync<T>(this HttpClient httpClient, HttpMethod httpMethod, Uri uri)
         where T : class
     {
         return SendAsJsonAsync<T>(httpClient, httpMethod, uri, null);
     }
-    
-    public static Task<T?> SendAsJsonAsync<T>(this HttpClient httpClient, HttpMethod httpMethod, Uri uri, object? payload)
+
+    internal static Task<T?> SendAsJsonAsync<T>(this HttpClient httpClient, HttpMethod httpMethod, Uri uri, object? payload)
         where T : class
     {
         return httpClient.SendAndProcessAsync<T>(httpMethod, uri, payload);


### PR DESCRIPTION
HttpClientExtensions is an SDK plumbing helper that has accidentally been public since the assembly was first published. Internal callers (PaymentOrderOperations, UserTokenOperations, PaymentOrdersResource, unit tests) are the only known users; the class is undocumented and not referenced from any sample.

Tightens the visibility of the class and all four extension methods (GetAsJsonAsync, PostAsJsonAsync, SendAsJsonAsync x2) from public to internal. Tests already have InternalsVisibleTo so they continue to compile.

Breaking change: external consumers (if any) who call these extension methods on their own HttpClient will no longer compile. The intended public API is ISwedbankPayClient / IPaymentOrdersResource. Requires a major version bump in the next release.