### PR TITLE
Bump Microsoft.Extensions.Http 3.1.9 to 8.0.1

### DIFF
--- a/src/SwedbankPay.Sdk.Extensions/SwedbankPay.Sdk.Extensions.csproj
+++ b/src/SwedbankPay.Sdk.Extensions/SwedbankPay.Sdk.Extensions.csproj
@@ -27,7 +27,7 @@
     </ItemGroup>
     
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.9" />
+      <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/SwedbankPay.Sdk.Tests/SwedbankPay.Sdk.Tests.csproj
+++ b/src/SwedbankPay.Sdk.Tests/SwedbankPay.Sdk.Tests.csproj
@@ -14,7 +14,7 @@
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
         <PackageReference Include="xunit" Version="2.7.0" />


### PR DESCRIPTION
3.1.9 targets the .NET Core 3.1 era (EOL since December 2022) and has not received security patches. Bumping to 8.0.1 — the latest patched 8.x release, matching the current LTS runtime — keeps the minimum requirement reasonable while restoring patch coverage.

PackageReference Version="8.0.1" means consumers must use at least 8.0.1; they are free to use higher versions if they want. Consumers on supported .NET runtimes (8/9/10) already have Microsoft.Extensions.Http 8.x or higher installed transitively, so this bump is effectively transparent for them. Consumers still on EOL .NET 6 or 7 must upgrade — but those runtimes are themselves out of support.