### PR TITLE
Bump development dependencies

### DIFF
--- a/src/Samples/Sample.AspNetCore.UiTests/package.json
+++ b/src/Samples/Sample.AspNetCore.UiTests/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "cypress": "^15.16.0",
-    "typescript": "^5.2.2"
+    "typescript": "^5.9.3"
   },
   "scripts": {
     "cy:open": "cypress open",

--- a/src/SwedbankPay.Sdk.IntegrationTests/SwedbankPay.Sdk.IntegrationTests.csproj
+++ b/src/SwedbankPay.Sdk.IntegrationTests/SwedbankPay.Sdk.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SwedbankPay.Sdk.Tests/SwedbankPay.Sdk.Tests.csproj
+++ b/src/SwedbankPay.Sdk.Tests/SwedbankPay.Sdk.Tests.csproj
@@ -11,18 +11,18 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-        <PackageReference Include="xunit" Version="2.7.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.8" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.2">
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
@@ -33,7 +33,7 @@
       <ProjectReference Include="..\SwedbankPay.Sdk.Infrastructure\SwedbankPay.Sdk.Infrastructure.csproj" />
       <ProjectReference Include="..\SwedbankPay.Sdk\SwedbankPay.Sdk.csproj" />
     </ItemGroup>
-    
+
     <ItemGroup>
       <None Remove="appsettings.json" />
       <Content Include="appsettings.json">


### PR DESCRIPTION
Refresh test, CI and tooling versions. None of these are visible to SDK consumers — they only affect the dev workflow.

NuGet (test projects):
- coverlet.collector              6.0.2  -> 10.0.1
- Microsoft.Extensions.*          8.0.x  -> 10.0.8
- Microsoft.NET.Test.Sdk          17.9.0 -> 18.6.0
- xunit                           2.7.0  -> 2.9.3
- xunit.runner.visualstudio       2.5.7  -> 3.1.5

GitHub Actions (now pinned to commit SHAs per repo policy, with the human-readable tag in a trailing comment):
- actions/checkout                v4     -> 93cb6ef... (v5)
- actions/setup-dotnet            v4     -> 67a3573...
- actions/upload-artifact         v4     -> ea165f8...
- azure/webapps-deploy            v3     -> 02a81be...
- cypress-io/github-action        v6     -> f790eee... (v6.10.9)
- dawidd6/action-download-artifact v10   -> 4c1e823...
- gittools/actions/gitversion/*   v3     -> 51d3256... (v3.2.1)
- LouisBrunner/checks-action      v2.0.0 -> 6b626ff...
- microsoft/variable-substitution v1     -> 6287962...
- potiuk/get-workflow-origin      v1_5   -> e2dae06...

UiTests:
- typescript                      5.2.2  -> 5.9.3

Verified: dotnet test passes (the only failure is the pre-existing GetPaymentOrder_ShouldReturnPaymentOrderReal that requires real API credentials and fails without them, unchanged by this bump).