### PR TITLE
fix(uitests): set Cypress tsconfig target to es2021 for TypeScript 6

### DIFF
--- a/src/Samples/Sample.AspNetCore.UiTests/cypress/tsconfig.json
+++ b/src/Samples/Sample.AspNetCore.UiTests/cypress/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["es5", "dom"],
+    "target": "es2021",
+    "lib": ["es2021", "dom"],
     "types": ["cypress", "node", "cypress-wait-until"]
   },
   "include": [


### PR DESCRIPTION
TypeScript 6.0 makes 'target: es5' a hard error (TS5107). Cypress 15 runs on modern Electron/Chrome/Node, so target es2021 (and matching lib) is the appropriate fix. Resolves the UI test webpack compilation failure introduced by the typescript 6.0.3 bump.