### PR TITLE
refactor(uitests): add retry mechanisms for token deletion and paymen…

### DIFF
--- a/src/Samples/Sample.AspNetCore.UiTests/cypress/e2e/elements/blocks/common/swedbank-block.ts
+++ b/src/Samples/Sample.AspNetCore.UiTests/cypress/e2e/elements/blocks/common/swedbank-block.ts
@@ -26,8 +26,27 @@ class SwedbankBlock {
 
     deleteToken(tokenType: string) {
         cy.getByAutomation('tokenslink', true, {timeout: 30000}).click();
-        cy.get('table.table tr[data-automation="' + tokenType + '"] td a.btn', {timeout: 30000}).first().click()
+        // A token from a just-completed payment can lag before GetOwnedTokens returns it. The
+        // My Page is server-rendered, so a normal cy.get retry would never see the row appear —
+        // reload the page until the token shows up (or give up after several attempts).
+        this.clickTokenRowWhenAvailable(tokenType, 10);
         cy.get('.alert.alert-success', {timeout: 5000}).should('have.class', 'alert-success');
+    }
+
+    private clickTokenRowWhenAvailable(tokenType: string, attemptsLeft: number) {
+        const selector = 'table.table tr[data-automation="' + tokenType + '"] td a.btn';
+        cy.get('body').then(($body) => {
+            if ($body.find(selector).length) {
+                cy.get(selector).first().click();
+            } else if (attemptsLeft > 1) {
+                cy.wait(3000);
+                cy.reload();
+                this.clickTokenRowWhenAvailable(tokenType, attemptsLeft - 1);
+            } else {
+                // Out of retries: let cy.get fail with its normal, descriptive assertion error.
+                cy.get(selector, {timeout: 30000}).first().click();
+            }
+        });
     }
 
     payWithCard() {

--- a/src/Samples/Sample.AspNetCore.UiTests/cypress/e2e/paymentorder/creditcard/creditcard-e2e.spec.cy.js
+++ b/src/Samples/Sample.AspNetCore.UiTests/cypress/e2e/paymentorder/creditcard/creditcard-e2e.spec.cy.js
@@ -48,7 +48,7 @@ describe('Pay with Credit card', () => {
             let paymentOrderLink = $paymentOrderLink.text();
             cy.getByAutomation('orderslink', true, {timeout: 30000}).click();
 
-            cy.getPaymentOrder(paymentOrderLink).then((response) => {
+            cy.getPaymentOrderUntil(paymentOrderLink, (body) => body.operations.capture != null).then((response) => {
                 expect(response.status).to.eq(200);
                 let responseBody = response.body;
 
@@ -63,7 +63,7 @@ describe('Pay with Credit card', () => {
                 cy.getByAutomation('a-paymentordercapture').should('be.visible').click();
             });
 
-            cy.getPaymentOrder(paymentOrderLink).then((response) => {
+            cy.getPaymentOrderUntil(paymentOrderLink, (body) => body.operations.reversal != null).then((response) => {
                 expect(response.status).to.eq(200);
                 let responseBody = response.body;
 
@@ -82,7 +82,7 @@ describe('Pay with Credit card', () => {
             });
 
 
-            cy.getPaymentOrder(paymentOrderLink).then((response) => {
+            cy.getPaymentOrderUntil(paymentOrderLink, (body) => body.paymentOrder.status.value === 'Reversed').then((response) => {
                 expect(response.status).to.eq(200);
                 let responseBody = response.body;
 

--- a/src/Samples/Sample.AspNetCore.UiTests/cypress/e2e/paymentorder/recurring/recurring-e2e.spec.cy.js
+++ b/src/Samples/Sample.AspNetCore.UiTests/cypress/e2e/paymentorder/recurring/recurring-e2e.spec.cy.js
@@ -70,7 +70,7 @@ describe('Create recurring payments', () => {
                 let paymentOrderLink = $paymentOrderLink.text();
                 cy.getByAutomation('orderslink', true, {timeout: 30000}).click();
 
-                cy.getPaymentOrder(paymentOrderLink).then((response) => {
+                cy.getPaymentOrderUntil(paymentOrderLink, (body) => body.operations.capture != null).then((response) => {
                     expect(response.status).to.eq(200);
                     let responseBody = response.body;
 
@@ -85,7 +85,7 @@ describe('Create recurring payments', () => {
                     cy.getByAutomation('a-paymentordercapture').should('be.visible').click();
                 });
 
-                cy.getPaymentOrder(paymentOrderLink).then((response) => {
+                cy.getPaymentOrderUntil(paymentOrderLink, (body) => body.operations.reversal != null).then((response) => {
                     expect(response.status).to.eq(200);
                     let responseBody = response.body;
 
@@ -103,7 +103,7 @@ describe('Create recurring payments', () => {
                     cy.getByAutomation('a-paymentorderreversal').should('be.visible').click();
                 });
 
-                cy.getPaymentOrder(paymentOrderLink).then((response) => {
+                cy.getPaymentOrderUntil(paymentOrderLink, (body) => body.paymentOrder.status.value === 'Reversed').then((response) => {
                     expect(response.status).to.eq(200);
                     let responseBody = response.body;
 
@@ -186,7 +186,7 @@ describe('Create recurring payments', () => {
                 let paymentOrderLink = $paymentOrderLink.text();
                 cy.getByAutomation('orderslink', true, {timeout: 30000}).click();
 
-                cy.getPaymentOrder(paymentOrderLink).then((response) => {
+                cy.getPaymentOrderUntil(paymentOrderLink, (body) => body.operations.capture != null).then((response) => {
                     expect(response.status).to.eq(200);
                     let responseBody = response.body;
 
@@ -201,7 +201,7 @@ describe('Create recurring payments', () => {
                     cy.getByAutomation('a-paymentordercapture').should('be.visible').click();
                 });
 
-                cy.getPaymentOrder(paymentOrderLink).then((response) => {
+                cy.getPaymentOrderUntil(paymentOrderLink, (body) => body.operations.reversal != null).then((response) => {
                     expect(response.status).to.eq(200);
                     let responseBody = response.body;
 
@@ -219,7 +219,7 @@ describe('Create recurring payments', () => {
                     cy.getByAutomation('a-paymentorderreversal').should('be.visible').click();
                 });
 
-                cy.getPaymentOrder(paymentOrderLink).then((response) => {
+                cy.getPaymentOrderUntil(paymentOrderLink, (body) => body.paymentOrder.status.value === 'Reversed').then((response) => {
                     expect(response.status).to.eq(200);
                     let responseBody = response.body;
 

--- a/src/Samples/Sample.AspNetCore.UiTests/cypress/e2e/paymentorder/swish/swish-e2e.spec.cy.js
+++ b/src/Samples/Sample.AspNetCore.UiTests/cypress/e2e/paymentorder/swish/swish-e2e.spec.cy.js
@@ -22,7 +22,7 @@ describe('Pay with Swish', () => {
             let paymentOrderLink = $paymentOrderLink.text();
             cy.getByAutomation('orderslink', true, {timeout: 30000}).click();
 
-            cy.getPaymentOrder(paymentOrderLink).then((response) => {
+            cy.getPaymentOrderUntil(paymentOrderLink, (body) => body.operations.reversal != null).then((response) => {
                 expect(response.status).to.eq(200);
                 let responseBody = response.body;
 
@@ -43,7 +43,7 @@ describe('Pay with Swish', () => {
 
             cy.get('.alert.alert-success', {timeout: 5000}).should('have.class', 'alert-success');
 
-            cy.getPaymentOrder(paymentOrderLink).then((response) => {
+            cy.getPaymentOrderUntil(paymentOrderLink, (body) => body.paymentOrder.status.value === 'Reversed').then((response) => {
                 expect(response.status).to.eq(200);
                 let responseBody = response.body;
                 expect(responseBody.paymentOrder.status.value).to.eq('Reversed');

--- a/src/Samples/Sample.AspNetCore.UiTests/cypress/support/index.ts
+++ b/src/Samples/Sample.AspNetCore.UiTests/cypress/support/index.ts
@@ -160,6 +160,12 @@ declare namespace Cypress {
         getPaymentOrder<T = any>(
             paymentOrderId: string
         ): Cypress.Chainable<Response<T>>
+
+        getPaymentOrderUntil<T = any>(
+            paymentOrderId: string,
+            predicate: (body: any) => boolean,
+            attempts?: number
+        ): Cypress.Chainable<Response<T>>
     }
 }
 
@@ -377,5 +383,25 @@ Cypress.Commands.add("findInIframeIf",
 Cypress.Commands.add("getPaymentOrder",
     (paymentOrderId: string) => {
         return cy.request('https://localhost:5001/payment/getpaymentorder?paymentorderid=' + paymentOrderId)
+    }
+);
+
+// Operations such as capture and reversal settle asynchronously at Swedbank Pay: the operation
+// POST can succeed while a follow-up GET still reports the previous state for a short window.
+// Poll the payment order until `predicate(body)` holds (or attempts run out) so assertions run
+// against the settled state instead of racing the transition.
+Cypress.Commands.add("getPaymentOrderUntil",
+    (paymentOrderId: string, predicate: (body: any) => boolean, attempts: number = 10) => {
+        const request = (attemptsLeft: number): any =>
+            cy.request('https://localhost:5001/payment/getpaymentorder?paymentorderid=' + paymentOrderId)
+                .then((response) => {
+                    if (predicate(response.body) || attemptsLeft <= 1) {
+                        return response;
+                    }
+                    cy.wait(2000);
+                    return request(attemptsLeft - 1);
+                });
+
+        return request(attempts);
     }
 );

--- a/src/Samples/Sample.AspNetCore/Controllers/TokensController.cs
+++ b/src/Samples/Sample.AspNetCore/Controllers/TokensController.cs
@@ -126,9 +126,12 @@ public class TokensController : Controller
             }
             viewModel.Cart = _cart;
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            _logger.LogError("No existing tokens for user");
+            // GetOwnedTokens throws when the payer owns no tokens yet (e.g. the token from a
+            // just-completed payment has not propagated). Log the real exception so CI can tell
+            // a benign "no tokens" 404 apart from auth/timeout failures instead of masking it.
+            _logger.LogError(ex, "Could not fetch tokens for payer {PayerReference}", _payerReference.Id);
         }
 
         return viewModel;


### PR DESCRIPTION
…t order operations

- Introduced `clickTokenRowWhenAvailable` to handle delays in token visibility.
- Replaced `cy.getPaymentOrder` with `cy.getPaymentOrderUntil` for polling payment order states.
- Updated logging in `TokensController` to improve error traceability for token retrieval failures.